### PR TITLE
Enable to set environment parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ unicorn_systemd::exec_start: /usr/local/bin/unicorn /srv/sample.ru
 - `working_directory`: The working directory for executed processes. Valid options: an absolute path.  Default to undef.
 - `listen_streams`: The addresses to listen on for a stream. Valid options: an array of valid addresses.  Default to ['127.0.0.1:8080', '/var/run/unicorn.sock'].
 - `exec_start`: The commands with their arguments that are executed for this service. Valid options: a string containing valid commands.  Default to undef.
+- `environment`: The environment variables for executed processes. Valid options: a hash of key-value pairs.  Default to {}.
 - `service_ensure`: Whether the service should be enabled. Valid options: 'running', 'true', 'stopped', or 'false'.  Defaults to running.
 - `service_enable`: Whether the service should be enabled. Valid options: a boolean.  Defaults to true.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -31,8 +31,6 @@ module VagrantPlugins
   end
 end
 
-require 'json'
-
 platforms = {
   centos7: 'puppetlabs/centos-7.2-64-puppet',
   jessie: 'puppetlabs/debian-8.2-64-puppet',
@@ -43,6 +41,10 @@ Vagrant.configure(2) do |config|
     config.cache.scope = :box
   end
 
+  require 'fileutils'
+  FileUtils.mkdir_p 'tests/modules'
+
+  require 'json'
   metadata = JSON.parse(File.read('metadata.json'))
   module_name = metadata['name'].split('-').last
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,10 @@
 # The commands with their arguments that are executed for this service. Valid options: a string containing valid commands.
 # Default to undef.
 #
+# * `environment`
+# The environment variables for executed processes. Valid options: a hash of key-value pairs.
+# Default to {}.
+#
 # * `service_ensure`
 # Whether the service should be enabled. Valid options: 'running', 'true', 'stopped', or 'false'.
 # Defaults to running.
@@ -55,6 +59,7 @@ class unicorn_systemd (
   $working_directory = undef,
   $listen_streams    = ['127.0.0.1:8080', '/var/run/unicorn.sock'],
   $exec_start        = undef,
+  $environment       = {},
 
   $service_ensure    = running,
   $service_enable    = true,
@@ -67,6 +72,7 @@ class unicorn_systemd (
     working_directory => $working_directory,
     listen_streams    => $listen_streams,
     exec_start        => $exec_start,
+    environment       => $environment,
   }
 
   class { 'unicorn_systemd::service':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,6 +5,7 @@ class unicorn_systemd::install (
   $working_directory = undef,
   $listen_streams    = ['127.0.0.1:8080', '/var/run/unicorn.sock'],
   $exec_start        = undef,
+  $environment       = {},
 ){
 
   validate_string($user)
@@ -16,6 +17,7 @@ class unicorn_systemd::install (
     validate_array($listen_streams)
   }
   validate_string($exec_start)
+  validate_hash($environment)
 
   file {
     '/etc/systemd/system/unicorn.socket':

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -43,7 +43,8 @@ describe 'unicorn class' do
       }
 
       class { 'unicorn_systemd':
-        exec_start        => '/usr/local/bin/unicorn /srv/sample.ru',
+        exec_start        => '/usr/local/bin/unicorn -E $RAILS_ENV /srv/sample.ru',
+        environment       => { 'RAILS_ENV' => 'acceptance'},
         working_directory => '/srv',
         service_ensure    => running,
         service_enable    => true,
@@ -107,7 +108,8 @@ describe 'unicorn class' do
     it { should be_mode 644 }
     its(:content) { should match /^User = nobody$/ }
     its(:content) { should match %r|^WorkingDirectory = /srv$| }
-    its(:content) { should match %r|^ExecStart = /usr/local/bin/unicorn /srv/sample.ru$| }
+    its(:content) { should match %r|^ExecStart = /usr/local/bin/unicorn -E \$RAILS_ENV /srv/sample.ru$| }
+    its(:content) { should match /^Environment = "RAILS_ENV=acceptance"$/ }
   end
 
   describe service('unicorn.socket') do

--- a/templates/unicorn@.service.erb
+++ b/templates/unicorn@.service.erb
@@ -19,6 +19,9 @@ Group = <%= @group %>
 <% if @working_directory -%>
 WorkingDirectory = <%= @working_directory %>
 <% end -%>
+<% @environment.each do |key, value| -%>
+Environment = "<%= "#{key}=#{value}" %>"
+<% end unless @environment.empty? -%>
 ExecStart = <%= @exec_start %>
 ExecReload = /bin/kill -HUP $MAINPID
 KillSignal = SIGQUIT

--- a/tests/hieradata/common.yaml
+++ b/tests/hieradata/common.yaml
@@ -4,4 +4,6 @@ unicorn_systemd::working_directory: /srv
 unicorn_systemd::listen_streams:
   - 0.0.0.0:9000
   - 0.0.0.0:9001
-unicorn_systemd::exec_start: /usr/local/bin/unicorn /srv/sample.ru
+unicorn_systemd::exec_start: /usr/local/bin/unicorn -E $UNICORN_ENV /srv/sample.ru
+unicorn_systemd::environment:
+  UNICORN_ENV: tests

--- a/tests/manifests/init.pp
+++ b/tests/manifests/init.pp
@@ -35,6 +35,13 @@ if $::osfamily == 'RedHat' {
   }
 }
 
+user { 'app':
+  ensure     => present,
+  managehome => true,
+  home       => '/srv',
+  before     => Class['unicorn_systemd'],
+}
+
 package { 'unicorn':
   ensure          => installed,
   provider        => gem,


### PR DESCRIPTION
`environment` parameter is the environment variables for executed processes in systemd.
A hash of key-value pairs like `{ 'RAILS_ENV => 'production' }`.