### PR TITLE
newer version of camptocamp-systemd maybe works

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "camptocamp-systemd",
-      "version_requirement": ">= 0.0.0 < 1.0.0"
+      "version_requirement": ">= 0.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
the newest version of camptocamp-systemd is Ver2.2.0 now.

Ver1.0.0
https://forge.puppet.com/camptocamp/systemd/changelog#100-2017-09-04

Ver2.0.0
https://forge.puppet.com/camptocamp/systemd/changelog#200-2018-07-11

two major version up seems to have no breaking changes for this module.